### PR TITLE
adding bug reporting to contact page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -20,6 +20,10 @@ body {
     width: 850px;
     margin: 0 auto;
   }
+  .contact-container {
+    width: 225px;
+    margin: 5 auto;
+  }
   fieldset {
     display: block;
     -webkit-margin-start: 0px;

--- a/views/pages/contact-us-page.ejs
+++ b/views/pages/contact-us-page.ejs
@@ -26,23 +26,41 @@
 
         <div class="landing-img-container">
             <br>
-            <div>The easiest way of getting hold of us is by Github issues or social media</div>
-            <a href="https://github.com/Alpenglow88/otto-test-site" target="_blank">
-                <br>
-                <br>
-                <div>
-                    <span class="iconify" data-icon="logos:github-octocat" data-inline="true"></span>
-                    Project Github Repository
-                </div>
-            </a>
-            <a href="https://twitter.com/IanGoddard88" target="_blank">
-                <br>
-                <br>
-                <div>
-                    <span class="iconify" data-icon="logos:twitter" data-inline="true"></span>
-                    Maintainer Twitter
-                </div>
-            </a>
+            <div>The easiest way of getting hold of us is by Github or social media</div>
+            <div class="contact-container">
+                <a href="https://github.com/Alpenglow88/otto-test-site" target="_blank">
+                    <br>
+                    <br>
+                    <div>
+                        <span class="iconify" data-icon="logos:github-octocat" data-inline="true"></span>
+                        Project Github Repository
+                    </div>
+                </a>
+                <a href="https://twitter.com/IanGoddard88" target="_blank">
+                    <br>
+                    <br>
+                    <div>
+                        <span class="iconify" data-icon="logos:twitter" data-inline="true"></span>
+                        Maintainer Twitter
+                    </div>
+                </a>
+            </div>
+        </div>
+
+        <div class="landing-img-container">
+            <br><br>
+            <div>Found a bug with the site? Let us know on Github!</div>
+            <div class="contact-container">
+                <a href="https://github.com/Alpenglow88/otto-test-site/issues/new?assignees=&labels=bug&template=bug_report.md&title=BUG+-+"
+                    target="_blank">
+                    <br>
+                    <br>
+                    <div>
+                        <span class="iconify" data-icon="logos:github-octocat" data-inline="true"></span>
+                        Report a bug!
+                    </div>
+                </a>
+            </div>
         </div>
 
 


### PR DESCRIPTION
**Summary**

Adding link to raise bugs with site directly to github repo on the contact us page (https://github.com/Alpenglow88/otto-test-site/issues/16)

**Have you tested your changes?**

Yes

**Did you update the documentation?**

N/A
